### PR TITLE
Fix metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,6 @@
 	"author": "Arjun Suresh",
 	"author_uri": "http://gateoverflow.in/user/Arjun",
 	"license": "GPLv2",
-	"min_q2a": "1.5"
+	"min_q2a": "1.5",
 	"load_order": "after_db_init" 
 }


### PR DESCRIPTION
The metadata.json was missing a semicolon after one of its entries. So that the plugin info on the admin panel was not shown and the name of the plugin was set to default: Unnamed Plugin.